### PR TITLE
Impl infer for Case

### DIFF
--- a/src/il/tos.nim
+++ b/src/il/tos.nim
@@ -20,9 +20,9 @@ proc `$`*(self: Pattern, typed: bool = false, regioned: bool = false, comment: b
 proc `$`*(self: Suite, typed: bool = false, regioned: bool = false, comment: bool = false): string
 proc `$`*(self: Value, typed: bool = false, regioned: bool = false, comment: bool = false): string
 proc `$`*(self: Region, typed: bool = false, regioned: bool = false, comment: bool = false): string
-proc `$`*(self: Comment, typed: bool = false, regioned: bool = false, comment: bool = false): string = 
+proc `$`*(self: Comment, typed: bool = false, regioned: bool = false, comment: bool = false): string =
     if self.isDoc: "##" & self.s else: "#" & self.s
-proc `$`*(self: seq[Comment], typed: bool = false, regioned: bool = false, comment: bool = false): string = 
+proc `$`*(self: seq[Comment], typed: bool = false, regioned: bool = false, comment: bool = false): string =
     if comment: self.mapIt(`$`(it, typed, regioned, comment)).join("\n")
     else: self.filterIt(it.isDoc).mapIt(`$`(it, typed, regioned, comment)).join("\n")
 proc `$`*(self: Literal, typed: bool = false, regioned: bool = false, comment: bool = false): string =
@@ -60,12 +60,12 @@ proc `$$`*(self: Ident, typed: bool = false, regioned: bool = false, comment: bo
 proc `$`*(self: Suite, typed: bool = false, regioned: bool = false, comment: bool = false): string =
     self.stmts.mapIt(`$`(it, typed, regioned, comment)).join("\n").indent(2)
 proc `$`*(self: ElifBranch, typed: bool = false, regioned: bool = false, comment: bool = false): string =
-    let 
+    let
         cond = `$`(self.cond, typed, regioned, comment)
         suite = `$`(self.suite, typed, regioned, comment)
     &"elif {cond}:\n{suite}"
 proc `$`*(self: OfBranch, typed: bool = false, regioned: bool = false, comment: bool = false): string =
-    let 
+    let
         pat = `$`(self.pat, typed, regioned, comment)
         suite = `$`(self.suite, typed, regioned, comment)
     &"of {pat}:\n{suite}"
@@ -116,23 +116,27 @@ proc `$`*(self: Expression, typed: bool = false, regioned: bool = false, comment
     of ExpressionKind.Case:
         let
             val = `$`(self.val, typed, regioned, comment)
-            ofs = if self.ofs.len == 0: "" else: ("\n" & self.ofs.map(`$`).join("\n"))
             default = "\n" & self.default.map(
                     it => "default:\n" & `$`(it, typed, regioned, comment)
                 ).get("")
+        var
+            ofs = ""
+        for e in self.ofs:
+            ofs.add "\n"
+            ofs.add $e
         fmt"case {val}{ofs}{default}"
     of ExpressionKind.Call:
-        let 
+        let
             callee = `$`(self.callee, typed, regioned, comment)
             args = self.args.mapIt(`$`(it, typed, regioned, comment)).join(", ")
         fmt"{callee}({args})"
     of ExpressionKind.Command:
-        let 
+        let
             callee = `$`(self.callee, typed, regioned, comment)
             args = self.args.mapIt(`$`(it, typed, regioned, comment)).join(", ")
         fmt"{callee} {args}"
     of ExpressionKind.Dot:
-        let 
+        let
             lhs = `$`(self.lhs, typed, regioned, comment)
             rhs = `$`(self.rhs, typed, regioned, comment)
         fmt"{lhs}.{rhs}"
@@ -159,12 +163,12 @@ proc `$`*(self: Expression, typed: bool = false, regioned: bool = false, comment
             let blck = `$`(self.`block`, typed, regioned, comment)
             &"block:\n{blck}"
         else:
-            let 
+            let
                 label = `$`(self.label.get, typed, regioned, comment)
                 blck = `$`(self.`block`, typed, regioned, comment)
             &"block: {label}\n{blck}"
     of ExpressionKind.Bracket:
-        let 
+        let
             callee = `$`(self.callee, typed, regioned, comment)
             args = self.args.mapIt(`$`(it, typed, regioned, comment)).join(", ")
         fmt"{callee}[{args}]"
@@ -188,7 +192,7 @@ proc `$`*(self: Expression, typed: bool = false, regioned: bool = false, comment
         let rf = `$`(self.`ref`, typed, regioned, comment)
         fmt"ref {rf}"
     of ExpressionKind.FnType:
-        let 
+        let
             rety = `$`(self.rety, typed, regioned, comment)
             args = self.args.mapIt(`$`(it, typed, regioned, comment)).join(", ")
         fmt"func({args}) -> {rety}"
@@ -250,7 +254,7 @@ proc `$`*(self: IdentDef, typed: bool = false, regioned: bool = false, comment: 
         comments = if self.comments.len != 0: "\n" & fmt"{`$`(self.comments, typed, regioned, comment)}" else: ""
     fmt"{pat}{typ}{default}{comments}"
 proc `$`*(self: GenTypeDef, typed: bool = false, regioned: bool = false, comment: bool = false): string =
-    let 
+    let
         id = `$`(self.id, typed, regioned, comment)
         ub = if self.ub.isSome: fmt" <: {`$`(self.ub.get, typed, regioned, comment)}" else: ""
     fmt"{id}{ub}"
@@ -275,7 +279,7 @@ proc `$`*(self: FunctionParam, typed: bool = false, regioned: bool = false, comm
             else:
                 fmt"[{imp}]"
         params = self.params.mapIt(`$`(it, typed, regioned, comment)).join(", ")
-        rety = if self.rety.isNone: "" 
+        rety = if self.rety.isNone: ""
                else: fmt" -> {`$`(self.rety.get, typed, regioned, comment)}"
     fmt"{implicit}({params}){rety}"
 
@@ -288,7 +292,7 @@ proc `$`*(self: Function, typed: bool = false, regioned: bool = false, comment: 
         suite = if self.suite.isNone: "" else: ":\n" & fmt"{`$`(self.suite.get, typed, regioned, comment)}"
     &"{fn} {id}{param}{metadata}{suite}"
 
-proc `$`*(self: IdentDefSection, typed: bool = false, regioned: bool = false, comment: bool = false): string = 
+proc `$`*(self: IdentDefSection, typed: bool = false, regioned: bool = false, comment: bool = false): string =
     let
         # comments = if comment and self.comments.len != 0: self.comments.mapIt(`$`(it, typed, regioned, comment)).join("\n") & "\n" else: ""
         comments = if self.comments.len != 0: self.comments.mapIt(`$`(it, typed, regioned, comment)).join("\n") & "\n" else: ""
@@ -315,7 +319,7 @@ proc `$`*(self: Statement, typed: bool = false, regioned: bool = false, comment:
             let blck = `$`(self.`block`, typed, regioned, comment)
             &"loop\n{blck}"
         else:
-            let 
+            let
                 label = `$`(self.label.get, typed, regioned, comment)
                 blck = `$`(self.`block`, typed, regioned, comment)
             &"loop {label}\n{blck}"
@@ -388,7 +392,7 @@ proc `$`*(self: Trait, typed: bool = false, regioned: bool = false, comment: boo
         fmt"{fn}"
 
 proc `$`*(self: TraitType, typed: bool = false, regioned: bool = false, comment: bool = false): string =
-    let 
+    let
         pat = `$`(self.pat, typed, regioned, comment)
         typ = `$`(self.typ, typed, regioned, comment)
         traits =
@@ -544,12 +548,12 @@ proc `$`*(self: Value, typed: bool = false, regioned: bool = false, comment: boo
     of ValueKind.Union:
         toSeq(self.types).mapIt(`$`(it, typed, regioned, comment)).join"\/"
     of ValueKind.Select:
-        let 
+        let
             id = self.id.id2s(typed, regioned, comment)
             s = toSeq(self.types).mapIt(`$`(it, typed, regioned, comment)).join(" or ")
         fmt"'{id}({s})"
     of ValueKind.Lambda:
-        let 
+        let
             params = self.l_param.mapIt(`$`(it, typed, regioned, comment)).join(", ")
             suite = `$`(self.suite, typed, regioned, comment)
         &"lambda {params}: \n{suite}"
@@ -592,7 +596,7 @@ proc `$`*(self: Symbol, typed: bool = false, regioned: bool = false, comment: bo
             of SymbolKind.GenParam:
                 `$`(self.decl_gendef, typed, regioned, comment)
             of SymbolKind.Field:
-                "(" & 
+                "(" &
                 `$`(self.fielddef[0], typed, regioned, comment) &
                 ", " &
                 `$`(self.fielddef[1], typed, regioned, comment) &
@@ -653,7 +657,7 @@ proc treeRepr*(self: Expression): string =
         let members = self.members.mapIt(fmt"{it[0]}: {it[1]}").join(", ")
         fmt"({members})"
     of ExpressionKind.ObjCons:
-        let 
+        let
             typname = fmt"{self.typname}"
             members = self.members.mapIt(fmt"{it[0]}: {it[1]}").join(", ")
         fmt"{typname}({members})"

--- a/src/sema/eval.nim
+++ b/src/sema/eval.nim
@@ -19,6 +19,7 @@ import resolve
 
 
 proc infer*(self: Statement, env: TypeEnv, global: bool = false): Value
+proc infer*(self: Pattern, env: TypeEnv, global: bool = false, asign: bool = false): Value
 proc infer*(self: Suite, env: TypeEnv): Value
 proc infer*(self: ElifBranch, env: TypeEnv, global: bool = false): Value
 proc check(self: Expression, env: TypeEnv)
@@ -99,7 +100,18 @@ proc infer*(self: Expression, env: TypeEnv, global: bool = false): Value =
             env.coerce(elset.get <= tv)
         tv
     of ExpressionKind.Case:
-        Value.Unit
+        let
+            val = self.val.infer(env)
+            ofs = self.ofs.mapIt((it[0].infer(env), it[1].infer(env)))
+            default = self.default
+            tv = Value.Var(env)
+        for (pat, suite) in ofs:
+            debug suite
+            env.coerce(pat == val)
+            env.coerce(suite <= tv)
+        if default.isSome():
+            env.coerce(default.get.infer(env) <= tv)
+        tv
     of ExpressionKind.Call, ExpressionKind.Command:
         let
             tv = Value.Var(env)

--- a/src/sema/eval.nim
+++ b/src/sema/eval.nim
@@ -106,7 +106,6 @@ proc infer*(self: Expression, env: TypeEnv, global: bool = false): Value =
             default = self.default
             tv = Value.Var(env)
         for (pat, suite) in ofs:
-            debug suite
             env.coerce(pat == val)
             env.coerce(suite <= tv)
         if default.isSome():

--- a/test/unit.rgn
+++ b/test/unit.rgn
@@ -15,6 +15,19 @@ type
     x: int
     y: int
 
+func `tos@string/i32`(a: int) -> string ![importll]
+func `tos@string/float`(a: float) -> string ![importll]
+func `$`(a: int) -> string ![subtype]:
+    `tos@string/i32`(a)
+func `$`(a: float) -> string ![subtype]:
+    `tos@string/float`(a)
+
+func `to@float/i32`(a: int) -> float ![importll]
+func toFloat(a: int) -> float ![subtype]:
+    `to@float/i32`(a)
+
+func echo(a: string) ![importll]
+
 let a = Vec2(x: 1, y: 2)
 let a = case 1:
 of 0:
@@ -23,3 +36,5 @@ of 1:
     1.0
 default:
     2
+
+# echo a

--- a/test/unit.rgn
+++ b/test/unit.rgn
@@ -16,3 +16,10 @@ type
     y: int
 
 let a = Vec2(x: 1, y: 2)
+let a = case 1:
+of 0:
+    0
+of 1:
+    1.0
+default:
+    2


### PR DESCRIPTION
I implemented infer for Case, but in the case below(some branches have different types(int and float)) the type of variable `a` cannot be inferred.
I think infer I implemented works well. So I don't know why it doesn't work.
```
let a = case 1:
of 0:
  0
of 1:
  1.0
default
  2
```